### PR TITLE
return user_id in get chats

### DIFF
--- a/whats-app-bot-events/routes.js
+++ b/whats-app-bot-events/routes.js
@@ -41,11 +41,16 @@ router.get("/qr", (req, res) => {
 
 router.get("/chats", (req, res) => {
   client.getChats().then((chats) => {
-    if (!chats) {
-      return res.status(500).send("Error: could not export chats");
-    }
+  user_id = req.query.userId;
 
-    return res.status(200).send(chats);
+    if (!chats) {
+      return res.status(500).send("Error: could not export chats of user " + user_id);
+    }
+    response = {
+      "user id": user_id,
+      "chats": chats
+    }
+    return res.status(200).send(response);
   });
 });
 


### PR DESCRIPTION
Problems: 1. get chats return only the chats without user id
2. get chats route doesnt get userid as query
Solution: added query "?userId=" in get chats route and return this user id as well as the chats
Impact: changes in getchats route and in postman
Testing plan:
1. run docker compose and wait 10 sec
2. run GET /qr and scan
3. wait for "client is ready" in terminal and then wait 10 sec
4. run GET/chats with query "?userId=<use id here>" and check that you get back the user id and your groups
 for ex:
run - http://localhost:3001/chats?userId=23
get in responds-
"user id": "23",
    "chats": [.............