### PR TITLE
Change service name to bot_api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add chromium
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
-WORKDIR /home/node
+WORKDIR /home/bot_api
 
 COPY package.json .
 COPY package-lock.json .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  node:
+  bot_api:
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Problem: Current service name isn't intuitive. 
Solution: Change service name in docker config
Impact: init app
Testing plan: Start app using docker & test APIs