### PR TITLE
Change group id field in send message

### DIFF
--- a/whats-app-bot-events/routes.js
+++ b/whats-app-bot-events/routes.js
@@ -49,15 +49,15 @@ router.get("/chats", (req, res) => {
 });
 
 router.post("/sendMessage", (req, res) => {
-  group_id = req.body.group_id;
+  group_ids = req.body.group_ids;
   message_body = req.body.message_body;
-  message = sendMessages(group_id, message_body);
+  message = sendMessages(group_ids, message_body);
 
   if ("except" in message) {
     return res.status(404).send(message);
   }
   
-  return res.status(200).send("Message: " + message_body + " was sent succesfully to groups: " + group_id);
+  return res.status(200).send("Message: " + message_body + " was sent succesfully to groups: " + group_ids);
   
 });
 


### PR DESCRIPTION
Problem: group_id var should be group_ids
Solution: changed this var name in /POST sendMessage
Testing plan:

run docker compose and wait
run GET /qr and scan
wait for "client is ready" in terminal
run POST/sendmessage 
for ex:
{
"group_ids": ["120363028594091331@g.us"],
"message_body": "test"
}